### PR TITLE
feat:add  UseJSONNamesForFields setting

### DIFF
--- a/protoc-gen-openapiv2/generator/generator.go
+++ b/protoc-gen-openapiv2/generator/generator.go
@@ -9,12 +9,13 @@ import (
 
 // Generator is openapi v2 generator
 type Generator struct {
+	UseJSONNamesForFields bool
 }
 
 // Gen generates openapi v2 json content
 func (g *Generator) Gen(req *pluginpb.CodeGeneratorRequest, onlyRPC bool) (*pluginpb.CodeGeneratorResponse, error) {
 	reg := descriptor.NewRegistry()
-	reg.SetUseJSONNamesForFields(true)
+	reg.SetUseJSONNamesForFields(g.UseJSONNamesForFields)
 	reg.SetRecursiveDepth(1024)
 	reg.SetMergeFileName("apidocs")
 	reg.SetGenerateRPCMethods(onlyRPC)


### PR DESCRIPTION
并不是所有的项目 UseJSONNamesForFields 都是true，有一些项目是需要设置为false因此需要暴露这个值用于配置
